### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,78 @@
 debug.log
 kondate.pdf
 notice.json
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows,macos,linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos,linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux


### PR DESCRIPTION
## 概要

- Update `.gitignore` . 

## 変更点の詳細

- `.gitignore` defines files that the git system excludes.
  -  For example, files created by the OS such as `.DS_Store` and `Thumbs.db` should be ignored.
  - To create `.gitignore`, we usually use https://www.toptal.com/developers/gitignore .

## 動作確認

- 行った動作確認を記述(例:FireFox,Chrome,Microsoft Edge にて JavaScript の正常動作を確認)

## その他

- なし
